### PR TITLE
Checking if self.manifestDB is set, otherwise TypeError is raised

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -135,7 +135,8 @@ class iOSbackup(object):
 
     def close(self):
         try:
-            os.remove(self.manifestDB)
+            if self.manifestDB:
+                os.remove(self.manifestDB)
         except FileNotFoundError:
             # Its OK if manifest temporary file is not there anymore
             pass


### PR DESCRIPTION
If for some reason the decryption fails, this `close()` is called by `__del__` without `self.manifestDB`, which raises a TypeError exception. Checking first before calling os.remove.