### PR TITLE
Include support for ios older than 10.2

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -225,7 +225,7 @@ class iOSbackup(object):
             classKeys=pprint.pformat(self.classKeys, indent=4),
             IsEncrypted=self.manifest['IsEncrypted'],
             PasscodeSet=self.manifest['WasPasscodeSet'],
-            ManifestKey=self.manifest['ManifestKey'].hex(),
+            ManifestKey='Not applicable' if isOlderThaniOS10dot2(self.manifest['Lockdown']['ProductVersion']) else self.manifest['ManifestKey'].hex(),
             Applications=pprint.pformat(self.manifest['Applications'], indent=4),
             manifestDB=self.manifestDB,
             name=self.manifest['Lockdown']['DeviceName'],
@@ -1031,12 +1031,17 @@ class iOSbackup(object):
         with open(os.path.join(self.backupRoot,self.udid,iOSbackup.catalog['manifestDB']), 'rb') as db:
             encrypted_db = db.read()
 
-        manifest_class = struct.unpack('<l', self.manifest['ManifestKey'][:4])[0]
-        manifest_key   = self.manifest['ManifestKey'][4:]
+        # Before iOS 10.2 the manifest database was not encrypted in the backups. So, there is no need for decryption.
+        # Also, the ManifestKey is not presented in the Plist, so all references to 'ManifestKey' would result in KeyError
+        if isOlderThaniOS10dot2(self.manifest['Lockdown']['ProductVersion']):
+            decrypted_data = encrypted_db
+        else:        
+            manifest_class = struct.unpack('<l', self.manifest['ManifestKey'][:4])[0]
+            manifest_key   = self.manifest['ManifestKey'][4:]
 
-        key = self.unwrapKeyForClass(manifest_class, manifest_key)
+            key = self.unwrapKeyForClass(manifest_class, manifest_key)
 
-        decrypted_data = iOSbackup.AESdecryptCBC(encrypted_db, key)
+            decrypted_data = iOSbackup.AESdecryptCBC(encrypted_db, key)
 
 #         print(len(decrypted_data))
 
@@ -1112,10 +1117,13 @@ class iOSbackup(object):
         except:
             hlib = import_module('hashlib')
 
-
-        temp = hlib.pbkdf2_hmac('sha256', cleanpassword,
-            self.attrs[b"DPSL"],
-            self.attrs[b"DPIC"], 32)
+        # if the ios is older that 10.2, the stage with the DPSL and DPIC are not used in the key derivation
+        if isOlderThaniOS10dot2(self.manifest['Lockdown']['ProductVersion']):
+            temp = cleanpassword
+        else:
+            temp = hlib.pbkdf2_hmac('sha256', cleanpassword,
+                self.attrs[b"DPSL"],
+                self.attrs[b"DPIC"], 32)
 
         self.decryptionKey = hlib.pbkdf2_hmac('sha1', temp,
             self.attrs[b"SALT"],
@@ -1233,3 +1241,27 @@ class iOSbackup(object):
             yield (tag,data)
             i += 8 + length
 
+
+
+
+def isOlderThaniOS10dot2(version):
+    """Return boolean whether the version is older than ios 10.2 
+    
+    Parameters
+    ----------
+    version : str,
+        Version we want to compare. Assumes version is separated using point.
+    """
+    
+    versions = version.split('.')
+    if int(versions[0])<10:
+        return True
+    if int(versions[0])>10:
+        return False
+    if int(versions[0])==10:
+        if len(versions)==1: #str is ios 10 only
+            return True
+        if int(versions[1])<2:
+            return True
+        else:
+            return False


### PR DESCRIPTION
Changed the key derivation method to include the older key derivation method, used before the iOS 10.2. Based on the info available at https://irq5.io/2017/03/07/cracking-itunes-backup-passwords-with-hashcat/.

Before iOS 10.2, the manifest.db is not encrypted at all, so there is no Key "ManifestKey" available on the Manifest.plist. So, I added some conditionals to avoid getting KeyError when opening an older backup.

I tested on both and ios 10.1.1 backup and an ios 13 backup.