### PR TITLE
Updated mmap to run on Windows machines

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -965,8 +965,11 @@ class iOSbackup(object):
 
             # {BACKUP_ROOT}/{UDID}/ae/ae2c3d4e5f6...
             with open(os.path.join(self.backupRoot, self.udid, fileNameHash[:2], fileNameHash), 'rb') as inFile:
-                mappedInFile = mmap.mmap(inFile.fileno(), length=0, prot=mmap.PROT_READ)
-
+                if os.name == 'nt':
+                    mappedInFile = mmap.mmap(inFile.fileno(), length=0, access=mmap.ACCESS_READ)
+                else:
+                    mappedInFile = mmap.mmap(inFile.fileno(), length=0, prot=mmap.PROT_READ)
+                    
                 with open(targetFileName, 'wb') as outFile:
 
                     chunkIndex=0


### PR DESCRIPTION
mmap requires a different set of parameters on windows machines: https://stackoverflow.com/a/13500510

As of my tests this fixes file extraction on windows machines (testes with Python 3.9.4)