### PR TITLE
try & except reading long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 import setuptools
 from iOSbackup import __version__
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+try:
+    with open("README.md", "r") as fh:
+        long_description = fh.read()
+except Exception:
+    long_description = ""
 
 setuptools.setup(
     name="iOSbackup",


### PR DESCRIPTION
To be able to continue to install even when the readme cannot be read.

This happens in the following Windows build:

```python

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\VssAdministrator\AppData\Local\Temp\pip-req-build-4gomvpvz\setup.py", line 5, in <module>
        long_description = fh.read()
      File "C:\Miniconda\conda-bld\iosbackup_1632358722699\_h_env\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 10211: character maps to <undefined>

```

See https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=380040&view=logs&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=23010c01-6a9d-5f94-9037-792618644b77&l=2526