### PR TITLE
bugfix: setBackupRoot should treat None paths explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea

--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -270,7 +270,7 @@ class iOSbackup(object):
             Full path of folder that contains device backups. Uses platformFoldersHint if omitted.
         """
 
-        if path:
+        if path is not None:
             self.backupRoot=os.path.expanduser(os.path.expandvars(path))
         else:
             self.backupRoot=iOSbackup.getHintedBackupRoot()


### PR DESCRIPTION
Currently, when transferring a valid filename path within current directory, `setBackupRoot` will go look for the given filename inside iTunes directory instead.