### PR TITLE
Update win32 path in platformFoldersHint

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -116,7 +116,7 @@ class iOSbackup(object):
 
     platformFoldersHint = {
         'darwin': '~/Library/Application Support/MobileSync/Backup',
-        'win32': r'%HOME%\Apple Computer\MobileSync\Backup'
+        'win32': r'%APPDATA%\Apple Computer\MobileSync\Backup'
     }
 
     catalog = {


### PR DESCRIPTION
iTunes has changed its backup location to %APPDATA%\Apple Computer\MobileSync\Backup, so let's change the win32 path to reflect this :)