### PR TITLE
Allow for the possibility of an absent `Info.plist`

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -1096,8 +1096,11 @@ class iOSbackup(object):
 
 
         infoFile = os.path.join(self.backupRoot, self.udid, iOSbackup.catalog['info'])
-        with open(infoFile, 'rb') as infile:
-            self.info = plistlib.load(infile)
+        try:
+            with open(infoFile, 'rb') as infile:
+                self.info = plistlib.load(infile)
+        except:
+            self.info = None
 
 
 


### PR DESCRIPTION
I've recently encountered a backup where the `Info.plist` file was missing.

It is however not required to decrypt the backup.
Nevertheless decryption of a backup with the current code is not possible, because the file is opened once during the decryption process and then never used.

This PR circumvents the issue by wrapping the opening of the file in a `try` block. This makes the file available for future versions of the code, should it exist, while allowing the decryption of backups that don't need the file to exist.