### PR TITLE
Adding user profile backup directory as a fallback

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -116,7 +116,7 @@ class iOSbackup(object):
 
     platformFoldersHint = {
         'darwin': '~/Library/Application Support/MobileSync/Backup',
-        'win32': r'%APPDATA%\Apple Computer\MobileSync\Backup'
+        'win32': r'%APPDATA%\Apple Computer\MobileSync\Backup' if os.path.isdir(r'%APPDATA%\Apple Computer\MobileSync\Backup') else r'%USERPROFILE%\Apple\MobileSync\Backup'
     }
 
     catalog = {


### PR DESCRIPTION
Adding user profile backup directory as a fallback if the appdata backup directory does not exist. Some installations of Windows don't have the appdata backup directory.