### PR TITLE
Fix: Remove outFile.truncate(info['size'])

### DIFF
--- a/iOSbackup/__init__.py
+++ b/iOSbackup/__init__.py
@@ -996,7 +996,7 @@ class iOSbackup(object):
                         outFile.write(decryptor.decrypt(chunk))
                         chunkIndex+=1
 
-                    outFile.truncate(info['size'])
+                    #outFile.truncate(info['size'])
         elif info['isFolder']:
             # Plain folder
             Path(targetFileName).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Some files are cut too soon.

Without truncate, files are read to the EOF.

<img width="1271" height="520" alt="grafik" src="https://github.com/user-attachments/assets/60fefa47-7b91-4cc8-bb57-9623131fb48a" />

This shows an example. Left the correct size, right the wrongly cut file.